### PR TITLE
Pin orjson==3.8.7 to fix install on M1 and some python distros

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ caikit==0.3.1
 requests==2.30.0
 Pillow==9.5.0
 click==8.1.3
+orjson==3.8.7
 timm==0.9.1
 # backend only
 transformers[torch]==4.27.4


### PR DESCRIPTION
The orjson library used by gradio stopped building the wheels needed for M1. Pinning the old version has been confirmed as a workaround. These issues sometimes appear with Python versions on Intel also. That issue is less clear, but has also been fixed with this.

Fixes: #4
Fixes: #6